### PR TITLE
Save the segmentation as label file for Audacity

### DIFF
--- a/tools/ctc_segmentation/scripts/utils.py
+++ b/tools/ctc_segmentation/scripts/utils.py
@@ -117,6 +117,12 @@ def get_segments(
         segments = determine_utterance_segments(config, utt_begin_indices, char_probs, timings, text, char_list)
 
         write_output(output_file, path_wav, segments, text, text_no_preprocessing, text_normalized)
+        
+        # Also writes labels in audacity format
+        output_file_audacity = output_file[:-4] + "_audacity.txt"
+        write_labels_for_audacity(output_file_audacity, segments, text_no_preprocessing)
+        logging.info(f"Label file for Audacity written to {output_file_audacity}.")
+        
         for i, (word, segment) in enumerate(zip(text, segments)):
             if i < 5:
                 logging.debug(f"{segment[0]:.2f} {segment[1]:.2f} {segment[2]:3.4f} {word}")
@@ -292,4 +298,36 @@ def write_output(
                 start, end, score = segment
                 outfile.write(
                     f"{start} {end} {score} | {text[i]} | {text_no_preprocessing[i]} | {text_normalized[i]}\n"
+                )
+
+def write_labels_for_audacity(
+    out_path: str,
+    segments: List[Tuple[float]],
+    text_no_preprocessing: str,
+):
+    """
+    Write the segmentation output to a file ready to be imported in Audacity with the unprocessed text as labels
+
+    out_path: Path to output file
+    segments: Segments include start, end and alignment score
+    text_no_preprocessing: Reference txt without any pre-processing
+    """
+    # AUdacity uses tab to separate each field (start end text)
+    TAB_CHAR = "	"
+
+    # Uses char-wise alignments to get utterance-wise alignments and writes them into the given file
+    with open(str(out_path), "w") as outfile:
+
+        for i, segment in enumerate(segments):
+            if isinstance(segment, list):
+                for j, x in enumerate(segment):
+                    start, end, score = x
+                    score = -0.2
+                    outfile.write(
+                        f"{start}{TAB_CHAR}{end}{TAB_CHAR}{text_no_preprocessing[i][j]} \n"
+                    )
+            else:
+                start, end, score = segment
+                outfile.write(
+                     f"{start}{TAB_CHAR}{end}{TAB_CHAR}{text_no_preprocessing[i]} \n"
                 )


### PR DESCRIPTION
Audacity is a free open source audio editor that can import label file to quickly assess the segmentation quality. This commit adds the export to [Audacity label format](https://manual.audacityteam.org/man/importing_and_exporting_labels.html) so that directly after running the segmentation tool the segmentation quality can be assessed or the segmentation can be shared easily.

Signed-off-by: CaraDuf <91517923+Ca-ressemble-a-du-fake@users.noreply.github.com>

# What does this PR do ?

This PR adds the export to Audacity label file to quickly assess the segmentation work.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* No usage change. Audacity label file will be automatically generated in the segments output folder.


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
